### PR TITLE
fix: check-effect in onInstall and check if owner already existed in addOwner()

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -12,8 +12,8 @@ allow_paths = ["*", "/"]
 
 
 [rpc_endpoints]
-mainnet = "${MAINNET_RPC_URL}" 
-testnet = "${TESTNET_RPC_URL}" 
+mainnet = "${MAINNET_RPC_URL}"
+testnet = "${TESTNET_RPC_URL}"
 arbitrum = "https://arb-mainnet.g.alchemy.com/v2/${API_KEY_ALCHEMY}"
 arbitrum-sepolia = "https://arb-sepolia.g.alchemy.com/v2/${API_KEY_ALCHEMY}"
 avalanche = "https://avax-mainnet.g.alchemy.com/v2/${API_KEY_ALCHEMY}"


### PR DESCRIPTION
@kopy-kat I made a small enhancement in Ownable validator.

If you are okay with the change direction, I can add back a test case for `addOwner()` and update the .tree file.

The change in `onInstall()` is just perform all the checks first before updating the storage.