### PR TITLE
Add pub key to CredentialAdded event (WebauthValidator)

### DIFF
--- a/src/WebAuthnValidator/WebAuthnValidator.sol
+++ b/src/WebAuthnValidator/WebAuthnValidator.sol
@@ -80,7 +80,9 @@ contract WebAuthnValidator is ERC7579HybridValidatorBase {
     /// @param account The address of the smart account
     /// @param credentialId The ID of the added credential
     /// @param credential The WebAuthn credential
-    event CredentialAdded(address indexed account, bytes32 indexed credentialId, WebAuthnCredential credential);
+    event CredentialAdded(
+        address indexed account, bytes32 indexed credentialId, WebAuthnCredential credential
+    );
 
     /// @notice Emitted when a credential is removed from an account
     /// @param account The address of the smart account
@@ -304,7 +306,11 @@ contract WebAuthnValidator is ERC7579HybridValidatorBase {
             revert CredentialAlreadyExists();
         }
 
-        emit CredentialAdded(account, credentialId, WebAuthnCredential({ pubKeyX: pubKeyX, pubKeyY: pubKeyY, requireUV: requireUV }));
+        emit CredentialAdded(
+            account,
+            credentialId,
+            WebAuthnCredential({ pubKeyX: pubKeyX, pubKeyY: pubKeyY, requireUV: requireUV })
+        );
     }
 
     /// @notice Removes a WebAuthn credential from the account


### PR DESCRIPTION
The WebAuth standard does not allow for a `credentialId` -> `pub-key` lookup in the browser. Knowing the public key of a credential is essential for any integration with this contract (interacting via rhinestone sdk or any other custom integration)

Most people use event indexers as their db, so having this info on the event payload makes it a lot easier to track this state in any off-chain data layer. Ofc you can work around it by doing read-queries as a side effect of the existing event signature, but it's definitely something you always want to avoid if possible (1. it slows down indexing 2. reliance on querying an archive node when back-filling can introduce brittleness in the indexer which is annoying to deal with)

If you ever re-deploy this contract, please include this change. 

PS, the `credId` can easily be derived from the pubY and pubX (but not the other way around). If you'd like, you could probably remove the credId from the event all-together. 