### PR TITLE
fix(OwnableValidator): bump checknsignatures to revert-4-fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@erc7579/enumerablemap4337": "github:erc7579/enumerablemap",
     "@openzeppelin/contracts": "^5.3.0",
-    "@rhinestone/checknsignatures": "github:rhinestonewtf/checknsignatures",
+    "@rhinestone/checknsignatures": "github:rhinestonewtf/checknsignatures#revert-4-fix/checknsignatures",
     "@rhinestone/flatbytes": "github:rhinestonewtf/flatbytes",
     "@rhinestone/modulekit": "^0.5.9",
     "FreshCryptoLib": "github:rdubois-crypto/FreshCryptoLib",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       '@rhinestone/checknsignatures':
-        specifier: github:rhinestonewtf/checknsignatures
-        version: https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/f8389c186fb58480a9a42d598adebaa1a557762d
+        specifier: github:rhinestonewtf/checknsignatures#revert-4-fix/checknsignatures
+        version: https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/317b016704221f5e5951ff55173fcffd1d1d49a0
       '@rhinestone/flatbytes':
         specifier: github:rhinestonewtf/flatbytes
         version: https://codeload.github.com/rhinestonewtf/flatbytes/tar.gz/8182dc7353bef886be234c54ae36b1e33d6bf8ee
@@ -301,8 +301,8 @@ packages:
   '@prb/math@4.1.0':
     resolution: {integrity: sha512-ef5Xrlh3BeX4xT5/Wi810dpEPq2bYPndRxgFIaKSU1F/Op/s8af03kyom+mfU7gEpvfIZ46xu8W0duiHplbBMg==}
 
-  '@rhinestone/checknsignatures@https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/f8389c186fb58480a9a42d598adebaa1a557762d':
-    resolution: {tarball: https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/f8389c186fb58480a9a42d598adebaa1a557762d}
+  '@rhinestone/checknsignatures@https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/317b016704221f5e5951ff55173fcffd1d1d49a0':
+    resolution: {tarball: https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/317b016704221f5e5951ff55173fcffd1d1d49a0}
     version: 0.0.1
 
   '@rhinestone/erc4337-validation@0.0.5':
@@ -315,8 +315,8 @@ packages:
   '@rhinestone/modulekit@0.5.9':
     resolution: {integrity: sha512-Zc5Qo3dkyVhBo7OQRKOltYd+jlGCtV18TWSmpSvIdXKwUgo5xj8zL73wAwFKTww00zt/wXMbW6Z6ysIQWH3Ezw==}
 
-  '@rhinestone/sentinellist@https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/e722c5cc68c570d535bc3c9f85b3ce90cdc38807':
-    resolution: {tarball: https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/e722c5cc68c570d535bc3c9f85b3ce90cdc38807}
+  '@rhinestone/sentinellist@https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/4b03ebb52517035bd7bd6af4486f6428228cd763':
+    resolution: {tarball: https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/4b03ebb52517035bd7bd6af4486f6428228cd763}
     version: 1.0.1
 
   '@scure/base@1.1.9':
@@ -943,6 +943,10 @@ packages:
       debug:
         optional: true
 
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/620536fa5277db4e3fd46772d5cbc1ea0696fb43:
+    resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/620536fa5277db4e3fd46772d5cbc1ea0696fb43}
+    version: 1.16.1
+
   forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/6abf66980050ab03a35b52bdab814f55001d6929:
     resolution: {tarball: https://codeload.github.com/foundry-rs/forge-std/tar.gz/6abf66980050ab03a35b52bdab814f55001d6929}
     version: 1.9.6
@@ -1015,11 +1019,11 @@ packages:
 
   glob@5.0.15:
     resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -1699,12 +1703,12 @@ packages:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
-  solady@https://codeload.github.com/vectorized/solady/tar.gz/dcdfab80f4e6cb9ac35c91610b2a2ec42689ec79:
-    resolution: {tarball: https://codeload.github.com/vectorized/solady/tar.gz/dcdfab80f4e6cb9ac35c91610b2a2ec42689ec79}
-    version: 0.1.14
+  solady@git+https://git@github.com:vectorized/solady.git#90db92ce173856605d24a554969f2c67cadbc7e9:
+    resolution: {commit: 90db92ce173856605d24a554969f2c67cadbc7e9, repo: git@github.com:vectorized/solady.git, type: git}
+    version: 0.1.26
 
-  solarray@https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684:
-    resolution: {tarball: https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684}
+  solarray@git+https://git@github.com:sablier-labs/solarray.git#6bf10cb34cdace52a3ba5fe437e78cc82df92684:
+    resolution: {commit: 6bf10cb34cdace52a3ba5fe437e78cc82df92684, repo: git@github.com:sablier-labs/solarray.git, type: git}
     version: 1.0.0
 
   solc@0.8.26:
@@ -1798,6 +1802,7 @@ packages:
   test-value@2.1.0:
     resolution: {integrity: sha512-+1epbAxtKeXttkGFMTX9H42oqzOTufR1ceCF+GYA5aOmvaPq9wd4PUS8329fn2RRLGNeUkgRLnVpycjx8DsO2w==}
     engines: {node: '>=0.10.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -1900,6 +1905,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   web3-utils@1.10.4:
@@ -2398,10 +2404,10 @@ snapshots:
 
   '@prb/math@4.1.0': {}
 
-  '@rhinestone/checknsignatures@https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/f8389c186fb58480a9a42d598adebaa1a557762d':
+  '@rhinestone/checknsignatures@https://codeload.github.com/rhinestonewtf/checknsignatures/tar.gz/317b016704221f5e5951ff55173fcffd1d1d49a0':
     dependencies:
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/6abf66980050ab03a35b52bdab814f55001d6929
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/dcdfab80f4e6cb9ac35c91610b2a2ec42689ec79
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/620536fa5277db4e3fd46772d5cbc1ea0696fb43
+      solady: git+https://git@github.com:vectorized/solady.git#90db92ce173856605d24a554969f2c67cadbc7e9
 
   '@rhinestone/erc4337-validation@0.0.5(ethers@5.8.0)(hardhat@2.23.0(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))':
     dependencies:
@@ -2411,7 +2417,7 @@ snapshots:
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
       forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/8a225d81aa8e2e013580564588c79abb65eacc9e
       prettier: 2.8.8
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/dcdfab80f4e6cb9ac35c91610b2a2ec42689ec79
+      solady: git+https://git@github.com:vectorized/solady.git#90db92ce173856605d24a554969f2c67cadbc7e9
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -2432,12 +2438,12 @@ snapshots:
       '@ERC4337/account-abstraction-v0.6': accountabstraction@https://codeload.github.com/eth-infinitism/account-abstraction/tar.gz/7174d6d845618dbd11cee68eefa715f5263690b6(ethers@5.8.0)(hardhat@2.23.0(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
       '@prb/math': 4.1.0
       '@rhinestone/erc4337-validation': 0.0.5(ethers@5.8.0)(hardhat@2.23.0(typescript@4.9.5))(lodash@4.17.21)(typechain@5.2.0(typescript@4.9.5))
-      '@rhinestone/sentinellist': https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/e722c5cc68c570d535bc3c9f85b3ce90cdc38807
+      '@rhinestone/sentinellist': https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/4b03ebb52517035bd7bd6af4486f6428228cd763
       ds-test: https://codeload.github.com/dapphub/ds-test/tar.gz/e282159d5170298eb2455a6c05280ab5a73a4ef0
       excessively-safe-call: '@nomad-xyz/excessively-safe-call@https://codeload.github.com/nomad-xyz/ExcessivelySafeCall/tar.gz/81cd99ce3e69117d665d7601c330ea03b97acce0'
       forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/6abf66980050ab03a35b52bdab814f55001d6929
-      solady: https://codeload.github.com/vectorized/solady/tar.gz/dcdfab80f4e6cb9ac35c91610b2a2ec42689ec79
-      solarray: https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684
+      solady: git+https://git@github.com:vectorized/solady.git#90db92ce173856605d24a554969f2c67cadbc7e9
+      solarray: git+https://git@github.com:sablier-labs/solarray.git#6bf10cb34cdace52a3ba5fe437e78cc82df92684
       solhint: 5.0.5(typescript@4.9.5)
     transitivePeerDependencies:
       - bufferutil
@@ -2450,9 +2456,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@rhinestone/sentinellist@https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/e722c5cc68c570d535bc3c9f85b3ce90cdc38807':
+  '@rhinestone/sentinellist@https://codeload.github.com/rhinestonewtf/sentinellist/tar.gz/4b03ebb52517035bd7bd6af4486f6428228cd763':
     dependencies:
-      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/6abf66980050ab03a35b52bdab814f55001d6929
+      forge-std: https://codeload.github.com/foundry-rs/forge-std/tar.gz/620536fa5277db4e3fd46772d5cbc1ea0696fb43
 
   '@scure/base@1.1.9': {}
 
@@ -3211,6 +3217,8 @@ snapshots:
   follow-redirects@1.15.9(debug@4.4.0):
     optionalDependencies:
       debug: 4.4.0(supports-color@8.1.1)
+
+  forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/620536fa5277db4e3fd46772d5cbc1ea0696fb43: {}
 
   forge-std@https://codeload.github.com/foundry-rs/forge-std/tar.gz/6abf66980050ab03a35b52bdab814f55001d6929: {}
 
@@ -4044,9 +4052,9 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
-  solady@https://codeload.github.com/vectorized/solady/tar.gz/dcdfab80f4e6cb9ac35c91610b2a2ec42689ec79: {}
+  solady@git+https://git@github.com:vectorized/solady.git#90db92ce173856605d24a554969f2c67cadbc7e9: {}
 
-  solarray@https://codeload.github.com/sablier-labs/solarray/tar.gz/6bf10cb34cdace52a3ba5fe437e78cc82df92684: {}
+  solarray@git+https://git@github.com:sablier-labs/solarray.git#6bf10cb34cdace52a3ba5fe437e78cc82df92684: {}
 
   solc@0.8.26(debug@4.4.0):
     dependencies:


### PR DESCRIPTION
## Summary

- Pins `@rhinestone/checknsignatures` to the `revert-4-fix/checknsignatures` branch so the next `OwnableValidator` redeploy bakes in the un-bugged `checkNSignatures` (strict required-signatures count + revert on malformed contract sigs).
- Required for fixing ERC-1271 contract-owner flows (clients with smart-contract owners hit failures on the current default `OwnableValidator` deployment).
- All 51 OwnableValidator unit + integration tests pass against the new lib.

## Notes

- `pnpm install` also updated transitive `sentinellist` (`e722c5cc` → `4b03ebb5`) and `solady` (0.1.14 → 0.1.26). The new sentinellist's `popAll` resets `entries[SENTINEL] = SENTINEL` instead of leaving it cleared, which means `SentinelListLib.alreadyInitialized()` returns `true` after `popAll`.
- This **does not** affect OwnableValidator's behavior — its `isInitialized` checks `threshold[smartAccount] != 0`, not list state. SocialRecovery and WebAuthnValidator follow the same pattern and are also unaffected.
- It **does** break `OwnableExecutor` whose `isInitialized` calls `accountOwners[smartAccount].alreadyInitialized()` directly (2 integration tests now fail). OwnableExecutor is not part of this redeploy; tracking the fix separately.

## Test plan

- [x] `forge build` — compiles
- [x] `forge test --mp "test/OwnableValidator/**/*.sol"` — 51/51 pass
- [ ] Run targeted redeploy of OwnableValidator from this branch
- [ ] Verify on-chain `checkNSignatures` reverts on malformed contract-sig payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)