### PR TITLE
feat(MultiFactor): remove registry dependency

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+onlyBuiltDependencies:
+  - '@rhinestone/flatbytes'
+  - '@rhinestone/sentinellist'
+  - '@rhinestone/modulekit'
+  - '@rhinestone/module-bases'
+  - '@rhinestone/registry'
+  - '@rhinestone/safe7579'
+  - '@erc7579/enumerablemap4337'
+  - 'erc7579'
+  - 'forge-std'
+  - 'sentinellist'

--- a/src/MultiFactor/MultiFactor.sol
+++ b/src/MultiFactor/MultiFactor.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.25;
 
-import { ERC7579ValidatorBase, ERC7484RegistryAdapter } from "modulekit/Modules.sol";
+import { ERC7579ValidatorBase } from "modulekit/Modules.sol";
 import { PackedUserOperation } from "modulekit/external/ERC4337.sol";
-import { IStatelessValidator, IERC7484 } from "modulekit/Interfaces.sol";
-import { MODULE_TYPE_VALIDATOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
+import { IStatelessValidator } from "modulekit/Interfaces.sol";
 import {
     Validator,
     SubValidatorConfig,
@@ -21,7 +20,7 @@ import { ECDSA } from "solady/utils/ECDSA.sol";
  * @dev A validator that multiplexes multiple other validators
  * @author Rhinestone
  */
-contract MultiFactor is ERC7579ValidatorBase, ERC7484RegistryAdapter {
+contract MultiFactor is ERC7579ValidatorBase {
     using FlatBytesLib for *;
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -50,8 +49,6 @@ contract MultiFactor is ERC7579ValidatorBase, ERC7484RegistryAdapter {
     mapping(
         uint256 iteration => mapping(address subValidator => IterativeSubvalidatorRecord record)
     ) internal iterationToSubValidator;
-
-    constructor(IERC7484 _registry) ERC7484RegistryAdapter(_registry) { }
 
     /*//////////////////////////////////////////////////////////////////////////
                                      CONFIG
@@ -111,12 +108,6 @@ contract MultiFactor is ERC7579ValidatorBase, ERC7484RegistryAdapter {
                 id: id
             });
 
-            // check if the subValidator is an attested validator and revert if it is not
-            REGISTRY.checkForAccount({
-                smartAccount: account,
-                module: validatorAddress,
-                moduleType: MODULE_TYPE_VALIDATOR
-            });
             // set the subValidator data
             $validator.store(_validator.data);
 
@@ -224,13 +215,6 @@ contract MultiFactor is ERC7579ValidatorBase, ERC7484RegistryAdapter {
         MFAConfig storage $config = accountConfig[account];
         // cache the current iteration
         uint256 iteration = $config.iteration;
-
-        // check that the subValidator is an attested validator and revert if it is not
-        REGISTRY.checkForAccount({
-            smartAccount: msg.sender,
-            module: validatorAddress,
-            moduleType: MODULE_TYPE_VALIDATOR
-        });
 
         // get storage reference to subValidator config
         FlatBytesLib.Bytes storage $validator = $subValidatorData({

--- a/test/MultiFactor/integration/concrete/MultiFactor.t.sol
+++ b/test/MultiFactor/integration/concrete/MultiFactor.t.sol
@@ -41,7 +41,7 @@ contract MultiFactorIntegrationTest is BaseIntegrationTest {
     function setUp() public virtual override {
         BaseIntegrationTest.setUp();
 
-        validator = new MultiFactor(instance.aux.registry);
+        validator = new MultiFactor();
 
         subValidator1 = new OwnableValidator();
         subValidator2 = new OwnableValidator();

--- a/test/MultiFactor/unit/concrete/MultiFactor.t.sol
+++ b/test/MultiFactor/unit/concrete/MultiFactor.t.sol
@@ -15,7 +15,6 @@ import {
     parseValidationData,
     ValidationData
 } from "test/utils/ERC4337.sol";
-import { MockRegistry } from "test/mocks/MockRegistry.sol";
 import { MockValidator } from "test/mocks/MockValidator.sol";
 import { EIP1271_MAGIC_VALUE } from "test/utils/Constants.sol";
 
@@ -25,7 +24,6 @@ contract MultiFactorTest is BaseTest {
     //////////////////////////////////////////////////////////////////////////*/
 
     MultiFactor internal validator;
-    MockRegistry internal _registry;
     MockValidator internal subValidator1;
     MockValidator internal subValidator2;
 
@@ -42,8 +40,7 @@ contract MultiFactorTest is BaseTest {
     function setUp() public virtual override {
         BaseTest.setUp();
 
-        _registry = new MockRegistry();
-        validator = new MultiFactor(_registry);
+        validator = new MultiFactor();
 
         subValidator1 = new MockValidator();
         subValidator2 = new MockValidator();
@@ -104,19 +101,25 @@ contract MultiFactorTest is BaseTest {
         validator.onInstall(data);
     }
 
-    function test_OnInstallRevertWhen_AValidatorIsNotAttestedTo()
+    function test_OnInstallWhenValidatorIsNotAttestedTo()
         public
         whenModuleIsNotIntialized
         whenThresholdIsNot0
         whenOwnersLengthIsNotLessThanThreshold
     {
-        // it should revert
+        // it should install the validator without consulting a registry
+        address unattestedValidator = address(0x420);
         Validator[] memory validators = _getValidators();
-        validators[0].packedValidatorAndId = bytes32(abi.encodePacked(uint96(1), address(0x420)));
+        validators[0].packedValidatorAndId =
+            bytes32(abi.encodePacked(uint96(1), unattestedValidator));
         bytes memory data = abi.encodePacked(_threshold, abi.encode(validators));
 
-        vm.expectRevert();
         validator.onInstall(data);
+
+        bool isSubValidator = validator.isSubValidator(
+            address(this), unattestedValidator, ValidatorId.wrap(bytes12(uint96(1)))
+        );
+        assertTrue(isSubValidator);
     }
 
     function test_OnInstallWhenAllValidatorsAreAttestedTo()


### PR DESCRIPTION
## Summary
Removes the ERC-7484 registry dependency from `MultiFactor`. Drops `ERC7484RegistryAdapter` inheritance, the `IERC7484` constructor argument, and the `REGISTRY.checkForAccount` attestation checks in `onInstall` and `setValidator`. The module can now be deployed and used without a registry.

## Test plan
- [ ] Update existing `MultiFactor` test constructors to drop the registry argument
- [ ] Run `forge test` against the MultiFactor suites