### PR TITLE
feat(MultiFactor)!: drop the ERC-7484 registry dependency

### DIFF
--- a/src/MultiFactor/MultiFactor.sol
+++ b/src/MultiFactor/MultiFactor.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.25;
 
-import { ERC7579ValidatorBase, ERC7484RegistryAdapter } from "modulekit/Modules.sol";
+import { ERC7579ValidatorBase } from "modulekit/Modules.sol";
 import { PackedUserOperation } from "modulekit/external/ERC4337.sol";
-import { IStatelessValidator, IERC7484 } from "modulekit/Interfaces.sol";
-import { MODULE_TYPE_VALIDATOR } from "modulekit/accounts/common/interfaces/IERC7579Module.sol";
+import { IStatelessValidator } from "modulekit/Interfaces.sol";
 import {
     Validator,
     SubValidatorConfig,
@@ -21,7 +20,7 @@ import { ECDSA } from "solady/utils/ECDSA.sol";
  * @dev A validator that multiplexes multiple other validators
  * @author Rhinestone
  */
-contract MultiFactor is ERC7579ValidatorBase, ERC7484RegistryAdapter {
+contract MultiFactor is ERC7579ValidatorBase {
     using FlatBytesLib for *;
 
     /*//////////////////////////////////////////////////////////////////////////
@@ -50,8 +49,6 @@ contract MultiFactor is ERC7579ValidatorBase, ERC7484RegistryAdapter {
     mapping(
         uint256 iteration => mapping(address subValidator => IterativeSubvalidatorRecord record)
     ) internal iterationToSubValidator;
-
-    constructor(IERC7484 _registry) ERC7484RegistryAdapter(_registry) { }
 
     /*//////////////////////////////////////////////////////////////////////////
                                      CONFIG
@@ -111,12 +108,6 @@ contract MultiFactor is ERC7579ValidatorBase, ERC7484RegistryAdapter {
                 id: id
             });
 
-            // check if the subValidator is an attested validator and revert if it is not
-            REGISTRY.checkForAccount({
-                smartAccount: account,
-                module: validatorAddress,
-                moduleType: MODULE_TYPE_VALIDATOR
-            });
             // set the subValidator data
             $validator.store(_validator.data);
 
@@ -224,13 +215,6 @@ contract MultiFactor is ERC7579ValidatorBase, ERC7484RegistryAdapter {
         MFAConfig storage $config = accountConfig[account];
         // cache the current iteration
         uint256 iteration = $config.iteration;
-
-        // check that the subValidator is an attested validator and revert if it is not
-        REGISTRY.checkForAccount({
-            smartAccount: msg.sender,
-            module: validatorAddress,
-            moduleType: MODULE_TYPE_VALIDATOR
-        });
 
         // get storage reference to subValidator config
         FlatBytesLib.Bytes storage $validator = $subValidatorData({

--- a/test/MultiFactor/integration/concrete/MultiFactor.t.sol
+++ b/test/MultiFactor/integration/concrete/MultiFactor.t.sol
@@ -41,7 +41,7 @@ contract MultiFactorIntegrationTest is BaseIntegrationTest {
     function setUp() public virtual override {
         BaseIntegrationTest.setUp();
 
-        validator = new MultiFactor(instance.aux.registry);
+        validator = new MultiFactor();
 
         subValidator1 = new OwnableValidator();
         subValidator2 = new OwnableValidator();

--- a/test/MultiFactor/unit/concrete/MultiFactor.t.sol
+++ b/test/MultiFactor/unit/concrete/MultiFactor.t.sol
@@ -15,7 +15,6 @@ import {
     parseValidationData,
     ValidationData
 } from "test/utils/ERC4337.sol";
-import { MockRegistry } from "test/mocks/MockRegistry.sol";
 import { MockValidator } from "test/mocks/MockValidator.sol";
 import { EIP1271_MAGIC_VALUE } from "test/utils/Constants.sol";
 
@@ -25,7 +24,6 @@ contract MultiFactorTest is BaseTest {
     //////////////////////////////////////////////////////////////////////////*/
 
     MultiFactor internal validator;
-    MockRegistry internal _registry;
     MockValidator internal subValidator1;
     MockValidator internal subValidator2;
 
@@ -42,8 +40,7 @@ contract MultiFactorTest is BaseTest {
     function setUp() public virtual override {
         BaseTest.setUp();
 
-        _registry = new MockRegistry();
-        validator = new MultiFactor(_registry);
+        validator = new MultiFactor();
 
         subValidator1 = new MockValidator();
         subValidator2 = new MockValidator();
@@ -104,22 +101,7 @@ contract MultiFactorTest is BaseTest {
         validator.onInstall(data);
     }
 
-    function test_OnInstallRevertWhen_AValidatorIsNotAttestedTo()
-        public
-        whenModuleIsNotIntialized
-        whenThresholdIsNot0
-        whenOwnersLengthIsNotLessThanThreshold
-    {
-        // it should revert
-        Validator[] memory validators = _getValidators();
-        validators[0].packedValidatorAndId = bytes32(abi.encodePacked(uint96(1), address(0x420)));
-        bytes memory data = abi.encodePacked(_threshold, abi.encode(validators));
-
-        vm.expectRevert();
-        validator.onInstall(data);
-    }
-
-    function test_OnInstallWhenAllValidatorsAreAttestedTo()
+    function test_OnInstallWhenOwnersLengthIsNotLessThanThreshold()
         public
         whenModuleIsNotIntialized
         whenThresholdIsNot0
@@ -157,7 +139,7 @@ contract MultiFactorTest is BaseTest {
 
     function test_OnUninstallShouldIncrementTheIterator() public {
         // it should increment the iterator
-        test_OnInstallWhenAllValidatorsAreAttestedTo();
+        test_OnInstallWhenOwnersLengthIsNotLessThanThreshold();
 
         validator.onUninstall("");
 
@@ -167,7 +149,7 @@ contract MultiFactorTest is BaseTest {
 
     function test_OnUninstallShouldSetThresholdTo0() public {
         // it should set threshold to 0
-        test_OnInstallWhenAllValidatorsAreAttestedTo();
+        test_OnInstallWhenOwnersLengthIsNotLessThanThreshold();
 
         validator.onUninstall("");
 
@@ -183,7 +165,7 @@ contract MultiFactorTest is BaseTest {
 
     function test_IsInitializedWhenModuleIsIntialized() public {
         // it should return true
-        test_OnInstallWhenAllValidatorsAreAttestedTo();
+        test_OnInstallWhenOwnersLengthIsNotLessThanThreshold();
 
         bool isInitialized = validator.isInitialized(address(this));
         assertTrue(isInitialized);
@@ -199,7 +181,7 @@ contract MultiFactorTest is BaseTest {
 
     function test_SetThresholdRevertWhen_ThresholdIs0() public whenModuleIsIntialized {
         // it should revert
-        test_OnInstallWhenAllValidatorsAreAttestedTo();
+        test_OnInstallWhenOwnersLengthIsNotLessThanThreshold();
 
         vm.expectRevert(abi.encodeWithSelector(MultiFactor.ZeroThreshold.selector));
         validator.setThreshold(0);
@@ -207,7 +189,7 @@ contract MultiFactorTest is BaseTest {
 
     function test_SetThresholdWhenThresholdIsNot0() public whenModuleIsIntialized {
         // it should set the threshold
-        test_OnInstallWhenAllValidatorsAreAttestedTo();
+        test_OnInstallWhenOwnersLengthIsNotLessThanThreshold();
 
         uint8 newThreshold = 1;
         validator.setThreshold(newThreshold);
@@ -230,7 +212,7 @@ contract MultiFactorTest is BaseTest {
     function test_SetValidatorWhenModuleIsIntialized() public {
         // it should emit a ValidatorAdded event
         // it should set the validator data
-        test_OnInstallWhenAllValidatorsAreAttestedTo();
+        test_OnInstallWhenOwnersLengthIsNotLessThanThreshold();
 
         vm.expectEmit(true, true, true, true, address(validator));
         emit MultiFactor.ValidatorAdded({
@@ -293,7 +275,7 @@ contract MultiFactorTest is BaseTest {
 
     function test_IsSubValidatorWhenSubvalidatorIsInstalled() public {
         // it should return true
-        test_OnInstallWhenAllValidatorsAreAttestedTo();
+        test_OnInstallWhenOwnersLengthIsNotLessThanThreshold();
 
         bool isSubValidator = validator.isSubValidator(
             address(this), address(subValidator1), ValidatorId.wrap(bytes12(0))
@@ -314,7 +296,7 @@ contract MultiFactorTest is BaseTest {
 
     function test_ValidateUserOpWhenAnyValidatorIsNotSet() public whenValidatorLengthIsNotZero {
         // it should return 1
-        test_OnInstallWhenAllValidatorsAreAttestedTo();
+        test_OnInstallWhenOwnersLengthIsNotLessThanThreshold();
 
         PackedUserOperation memory userOp = getEmptyUserOperation();
 
@@ -338,7 +320,7 @@ contract MultiFactorTest is BaseTest {
         whenAllValidatorsAreSet
     {
         // it should return 1
-        test_OnInstallWhenAllValidatorsAreAttestedTo();
+        test_OnInstallWhenOwnersLengthIsNotLessThanThreshold();
 
         PackedUserOperation memory userOp = getEmptyUserOperation();
 
@@ -361,7 +343,7 @@ contract MultiFactorTest is BaseTest {
         whenAllValidatorsAreSet
     {
         // it should return 0
-        test_OnInstallWhenAllValidatorsAreAttestedTo();
+        test_OnInstallWhenOwnersLengthIsNotLessThanThreshold();
 
         PackedUserOperation memory userOp = getEmptyUserOperation();
 
@@ -393,7 +375,7 @@ contract MultiFactorTest is BaseTest {
         whenValidatorLengthIsNotZero
     {
         // it should return EIP1271_FAILED
-        test_OnInstallWhenAllValidatorsAreAttestedTo();
+        test_OnInstallWhenOwnersLengthIsNotLessThanThreshold();
 
         Validator[] memory validators = _getValidators();
         validators[1].packedValidatorAndId =
@@ -412,7 +394,7 @@ contract MultiFactorTest is BaseTest {
         whenAllValidatorsAreSet
     {
         // it should return EIP1271_FAILED
-        test_OnInstallWhenAllValidatorsAreAttestedTo();
+        test_OnInstallWhenOwnersLengthIsNotLessThanThreshold();
 
         Validator[] memory validators = _getValidators();
         validators[1].data = bytes("invalid");
@@ -430,7 +412,7 @@ contract MultiFactorTest is BaseTest {
         whenAllValidatorsAreSet
     {
         // it should return ERC1271_MAGIC_VALUE
-        test_OnInstallWhenAllValidatorsAreAttestedTo();
+        test_OnInstallWhenOwnersLengthIsNotLessThanThreshold();
 
         Validator[] memory validators = _getValidators();
 

--- a/test/MultiFactor/unit/concrete/MultiFactor.tree
+++ b/test/MultiFactor/unit/concrete/MultiFactor.tree
@@ -8,12 +8,9 @@ MultiFactor::onInstall
         ├── when owners length is less than threshold
         │   └── it should revert
         └── when owners length is not less than threshold
-            ├── when a validator is not attested to
-            │   └── it should revert
-            └── when all validators are attested to
-                ├── it should set threshold
-                ├── it should store the validators
-                └── it should emit a ValidatorAdded event for each validator
+            ├── it should set threshold
+            ├── it should store the validators
+            └── it should emit a ValidatorAdded event for each validator
      
 
 MultiFactor::onUninstall


### PR DESCRIPTION
## What

`MultiFactor` no longer inherits `ERC7484RegistryAdapter`, no longer takes an `IERC7484` in its constructor, and no longer calls `REGISTRY.checkForAccount` in `onInstall` / `setValidator`.

## Why

The check gated sub-validators on an attestation from the account's trusted attesters. **Nothing in our stack configures attesters.**

Against the live registry `0x000000000069E2a187AEFFb852bF3cCdC95151B2` — which is present on all 16 prod mainnets — `checkForAccount` for an account that never called `trustAttesters` reverts:

```
cast call <registry> "checkForAccount(address,address,uint256)" <acct> <module> 1
→ execution reverted, data: 0x05a74e61   // NoTrustedAttestersFound()
```

Verified identically on base, mainnet and arbitrum. So in practice the check could only ever block an install, never permit one.

The suite never caught this because `test/mocks/MockRegistry.sol` stubs the call out — it only implements the 2-arg `checkForAccount`, so the 3-arg selector hit no function and the one test asserting this behaviour passed on a bare `vm.expectRevert()` for the wrong reason.

## Breaking

The constructor signature changes, so bytecode and CREATE2 address change. **This is deliberately a new module.** The existing `MultiFactor` at `0xf6bDf42c9BE18cEcA5C06c42A43DAf7FBbe7896b` is live on 13 of 16 prod mainnets and keeps its current behaviour:

```
DEPLOYED  base arbitrum optimism bsc avalanche gnosis unichain
          sonic soneium katana polygon plasma monad
MISSING   mainnet, hyperevm
```

`MULTI_FACTOR_VALIDATOR_ADDRESS` in `module-sdk` still points at the old address and needs a decision before consumers move.

## Notes

- Removes the now-obsolete `test_OnInstallRevertWhen_AValidatorIsNotAttestedTo` and collapses the corresponding branch in the bulloak tree. The surviving helper is renamed off `...AreAttestedTo` since that condition no longer exists (14 call sites).
- 37/37 MultiFactor tests pass. `forge fmt` was **not** run — the repo isn't fmt-clean under the current forge version and it added ~60 lines of unrelated churn.
- `script/DeployScript.s.sol:251` has a commented-out deploy still passing `abi.encode(registry)`. Left as-is; it won't compile if uncommented.
- `HookMultiPlexer` has the identical `constructor(IERC7484 _registry)` and is deliberately untouched.
- Worth noting the deploy script uses `_registryDeploy` — the registry is also the **factory** for these modules, which is separate from the constructor dependency and is why yeet could never reproduce the old address anyway.

Relates to RHI-6080.

🤖 Generated with [Claude Code](https://claude.com/claude-code)